### PR TITLE
Update install.sh to install alsa-utils

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Installing dependencies..."
-sudo apt install alsa-tools
+sudo apt install alsa-tools alsa-utils
 
 echo "Copying files..."
 sudo cp huawei-soundcard-headphones-monitor.sh /usr/local/bin/


### PR DESCRIPTION
The command amixer is provided by the package alsa-utils, so it needs to be installed.