### PR TITLE
Add support for multiple package managers in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,18 @@
 #!/bin/bash
 
-echo "Installing dependencies..."
-sudo apt install alsa-tools alsa-utils
+if command -v apt &>/dev/null; then
+    echo "Using apt to install dependencies..."
+    sudo apt update
+    sudo apt install -y alsa-tools alsa-utils
+else
+    if command -v pacman &>/dev/null; then
+        echo "Using pacman to install dependencies..."
+        sudo pacman -Sy alsa-tools alsa-utils --noconfirm
+    else
+        echo "Neither apt nor pacman found. Cannot install dependencies."
+        exit 1
+    fi
+fi
 
 echo "Copying files..."
 sudo cp huawei-soundcard-headphones-monitor.sh /usr/local/bin/


### PR DESCRIPTION
This pull request adds support for multiple package managers in the install script. The script now checks if the system has apt or pacman installed and uses the appropriate package manager to install the required dependencies. This makes the script more versatile and compatible with different Linux distributions.

No issues were found during testing.