### PR TITLE
Should now work correctly upon reboot

### DIFF
--- a/huawei-soundcard-headphones-monitor.sh
+++ b/huawei-soundcard-headphones-monitor.sh
@@ -40,34 +40,24 @@ function switch_to_headphones() {
     sudo hda-verb /dev/snd/hwC0D0 0x1 0x717 0x2 > /dev/null 2> /dev/null # pin output mode
     sudo hda-verb /dev/snd/hwC0D0 0x1 0x716 0x2 > /dev/null 2> /dev/null # pin enable
     sudo hda-verb /dev/snd/hwC0D0 0x1 0x715 0x0 > /dev/null 2> /dev/null # clear pin value
+
+    pacmd set-sink-port alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp__sink "[Out] Headphones" # sets amixer sink port to headphones instead of the speaker
 }
 
 old_status=0
 
 while true; do
-    if amixer -c 0 get Headphone | grep -q "off"; then
+    if amixer -c 0 cget numid=14 | grep -q "values=off"; then
         status=1
         message="Headphones disconnected"
-        move_output_to_speaker
+	switch_to_speaker
     else
         status=2
         message="Headphones connected"
-        move_output_to_headphones
+        switch_to_headphones
     fi
 
     if [ ${status} -ne ${old_status} ]; then
-        case "${status}" in
-            1)
-                switch_to_headphones
-                sleep .1
-                switch_to_speaker
-                ;;
-            2)
-                switch_to_speaker
-                sleep .1
-                switch_to_headphones
-                ;;
-        esac
         echo "${message}"
         old_status=$status
     fi

--- a/huawei-soundcard-headphones-monitor.sh
+++ b/huawei-soundcard-headphones-monitor.sh
@@ -49,12 +49,10 @@ while true; do
         status=1
         message="Headphones disconnected"
         move_output_to_speaker
-        # switch_to_speaker
     else
         status=2
         message="Headphones connected"
         move_output_to_headphones
-        # switch_to_headphones
     fi
 
     if [ ${status} -ne ${old_status} ]; then

--- a/huawei-soundcard-headphones-monitor.sh
+++ b/huawei-soundcard-headphones-monitor.sh
@@ -16,6 +16,9 @@
 # Internal Speaker 0x17 is coupled with Headphone Jack 0x16 so it should be explicitly disabled with EAPD/BTL Enable command.
 #
 
+# ensures script can run only once at a time
+pidof -o %PPID -x $0 >/dev/null && echo "Script $0 already running" && exit 1
+
 function move_output() {
     sudo hda-verb /dev/snd/hwC0D0 0x16 0x701 "$@" > /dev/null 2> /dev/null
 }

--- a/huawei-soundcard-headphones-monitor.sh
+++ b/huawei-soundcard-headphones-monitor.sh
@@ -57,6 +57,8 @@ function switch_to_headphones() {
     pacmd set-sink-port alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp__sink "[Out] Headphones"
 }
 
+sleep 2 # allows audio system to initialise first
+
 old_status=0
 
 while true; do
@@ -64,18 +66,27 @@ while true; do
     if amixer -c 0 cget numid=14 | grep -q "values=off"; then
         status=1
         message="Headphones disconnected"
-	switch_to_speaker
+	move_output_to_speaker
     # if headphone jack is plugged:
     else
         status=2
         message="Headphones connected"
-        switch_to_headphones
+	move_output_to_headphones
     fi
 
     if [ ${status} -ne ${old_status} ]; then
+	case "${status}" in
+	    1)
+		switch_to_speaker
+		;;
+	    2)
+		switch_to_headphones
+		;;
+	esac
+	
         echo "${message}"
         old_status=$status
     fi
 
-    sleep 1
+    sleep .3
 done

--- a/huawei-soundcard-headphones-monitor.sh
+++ b/huawei-soundcard-headphones-monitor.sh
@@ -30,27 +30,42 @@ function move_output_to_headphones() {
 
 function switch_to_speaker() {
     move_output_to_speaker
-    sudo hda-verb /dev/snd/hwC0D0 0x17 0x70C 0x0002 > /dev/null 2> /dev/null # enable speaker
-    sudo hda-verb /dev/snd/hwC0D0 0x1 0x715 0x2 > /dev/null 2> /dev/null # disable headphones
+
+    # enable speaker
+    sudo hda-verb /dev/snd/hwC0D0 0x17 0x70C 0x0002 > /dev/null 2> /dev/null
+
+    # disable headphones
+    sudo hda-verb /dev/snd/hwC0D0 0x1 0x715 0x2 > /dev/null 2> /dev/null
 }
 
 function switch_to_headphones() {
     move_output_to_headphones
-    sudo hda-verb /dev/snd/hwC0D0 0x17 0x70C 0x0000 > /dev/null 2> /dev/null # disable speaker
-    sudo hda-verb /dev/snd/hwC0D0 0x1 0x717 0x2 > /dev/null 2> /dev/null # pin output mode
-    sudo hda-verb /dev/snd/hwC0D0 0x1 0x716 0x2 > /dev/null 2> /dev/null # pin enable
-    sudo hda-verb /dev/snd/hwC0D0 0x1 0x715 0x0 > /dev/null 2> /dev/null # clear pin value
 
-    pacmd set-sink-port alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp__sink "[Out] Headphones" # sets amixer sink port to headphones instead of the speaker
+    # disable speaker
+    sudo hda-verb /dev/snd/hwC0D0 0x17 0x70C 0x0000 > /dev/null 2> /dev/null
+
+    # pin output mode
+    sudo hda-verb /dev/snd/hwC0D0 0x1 0x717 0x2 > /dev/null 2> /dev/null
+
+    # pin enable
+    sudo hda-verb /dev/snd/hwC0D0 0x1 0x716 0x2 > /dev/null 2> /dev/null
+
+    # clear pin value
+    sudo hda-verb /dev/snd/hwC0D0 0x1 0x715 0x0 > /dev/null 2> /dev/null
+
+    # sets amixer sink port to headphones instead of the speaker
+    pacmd set-sink-port alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp__sink "[Out] Headphones"
 }
 
 old_status=0
 
 while true; do
+    # if headphone jack isn't plugged:
     if amixer -c 0 cget numid=14 | grep -q "values=off"; then
         status=1
         message="Headphones disconnected"
 	switch_to_speaker
+    # if headphone jack is plugged:
     else
         status=2
         message="Headphones connected"

--- a/huawei-soundcard-headphones-monitor.sh
+++ b/huawei-soundcard-headphones-monitor.sh
@@ -77,5 +77,5 @@ while true; do
         old_status=$status
     fi
 
-    sleep .3
+    sleep 1
 done

--- a/huawei-soundcard-headphones-monitor.sh
+++ b/huawei-soundcard-headphones-monitor.sh
@@ -68,21 +68,21 @@ while true; do
     # if headphone jack isn't plugged:
     if amixer -c 0 cget numid=14 | grep -q "values=off"; then
         status=1
-        message="Headphones disconnected"
 	move_output_to_speaker
     # if headphone jack is plugged:
     else
         status=2
-        message="Headphones connected"
 	move_output_to_headphones
     fi
 
     if [ ${status} -ne ${old_status} ]; then
 	case "${status}" in
 	    1)
+		message="Headphones disconnected"
 		switch_to_speaker
 		;;
 	    2)
+		message="Headphones connected"
 		switch_to_headphones
 		;;
 	esac

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,3 +1,6 @@
+echo "Stopping daemon..."
+sudo systemctl stop huawei-soundcard-headphones-monitor.service
+
 echo "Removing program..."
 sudo rm /usr/local/bin/huawei-soundcard-headphones-monitor.sh
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,7 @@
+echo "Removing program..."
+sudo rm /usr/local/bin/huawei-soundcard-headphones-monitor.sh
+
+echo "Removing service..."
+sudo rm /etc/systemd/system/huawei-soundcard-headphones-monitor.service
+
+echo "Uninstalled. Goodbye 😿"


### PR DESCRIPTION
Thank you for writing this daemon :smiley:. I have added some changes to it I thought you might be interested in. Mostly I have improved it to work immediately on login - rather than having to firstly plug/unplug something in/from the headphone jack before it can function as desired.

1. With every loop, it now checks `amixer -c 0 cget numid=14 | grep -q "values=off"` instead of `amixer -c 0 get Headphone | grep -q "off"`. This checks whether or not something is plugged into the headphone jack. With the way it was before, if the headphones were left in the jack before shutdown, but removed while the PC was off, it would still report the headphone mixer control as on. The 'Headphone Jack' (i.e. `numid=14`) card value is more responsive, as it doesn't have this behaviour (it correctly determines whether something is plugged in or not at system startup, instead of just loading a saved value).
2. Added `pacmd set-sink-port alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp__sink "[Out] Headphones"` to the `switch_to_headphones` function. Before, even when the speaker was disabled, the output was moved to the headphones, and the pin was enabled and cleared and whatnot, it still didn't automatically switch to the 'Headphones' port of the audio controller on boot up, as seen in the GNOME sound settings. This fixes this.
3. The `switch_to_headphones` or `switch_to_speaker` function is called with *every* loop. I imagine you put these in the `[ ${status} -ne ${old_status} ]` conditional statement for efficiency reasons, but with the way it was before, it wouldn't work correctly after doing things like disconnecting from another audio device (e.g. a Bluetooth device) or waking up from sleep, at least until the headphone jack was plugged/unplugged again. Now these side effects don't happen when the `switch_to_XXXX` functions are called every loop. I don't know if calling these functions every loop makes a significant impact on the device's power usage or not. I did increase the sleep time for every loop from .3 seconds to 1 second as I thought it would improve the daemon's power usage while having a negligible impact on user experience (slightly less tiny delay when plugging/unplugging the headphone jack before audio comes on).
4. Added an uninstaller.
5. Made the comments in `huawei-soundcard-headphones-monitor.sh` go on separate lines so the lines of code are short and don't wrap around the window.

I tested this on my Matebook 14s and it works quite nicely. Hopefully it works on other machines as well.